### PR TITLE
Replace file exists action with simple bash check for the file

### DIFF
--- a/.github/workflows/send-email.yaml
+++ b/.github/workflows/send-email.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
 
       - name: Last successful run
@@ -33,9 +33,10 @@ jobs:
 
       - name: Check email exists
         id: check_email
-        uses: andstor/file-existence-action@v2.0.0
-        with:
-          files: 'dist/email.html'
+        run: |
+          if [ -f dist/email.html ]; then
+            echo "files_exists=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Send email
         if: steps.check_email.outputs.files_exists == 'true'


### PR DESCRIPTION
The action `andstor/file-existence-action` still uses node 16 which is deprecated. There is a PR opened to update node, but that PR build has failed and I do not know how active maintenance is. 

But I think I can easily replace this with a simple shell script, which would reduce complexity and therefore be better.